### PR TITLE
⚡️ Faster filter for youtube welcome page

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ Go to [Brave filters settings](brave://settings/shields/filters), and copy-paste
 
 ```
 youtube.com##div#header > ytd-feed-filter-chip-bar-renderer
-youtube.com##div#contents > ytd-rich-grid-row
-youtube.com##div#contents > ytd-rich-section-renderer
+youtube.com##div#contents.ytd-rich-grid-renderer
 ```
 
 <details><summary>Remove the videos displayed on the home page of Youtube.</summary>


### PR DESCRIPTION
<!--- Put the name of the website and the element filtered in the title of the PR, for example `StackOverflow - Hot questions` --->

## 🔍️ Description

<!--- You can add additional informations here (optional) --->
Change the youtube welcome page filter, so that it filters the same element, but the page is faster to load.

## 🌱 Checklist

- [x] I read the [Contribution Guidelines](https://github.com/astariul/awesome-brave-filters/blob/main/CONTRIBUTING.md)
- [ ] This content filter is new, it doesn't exist in the list
- [x] The content filter added is properly formatted
- [x] It contains the content filter, a textual description, and an image
- [x] I put it in the right section
- [x] I tested the content filter and it doesn't break other parts of the website
- [x] I checked my spelling and grammar
